### PR TITLE
feat: /rss エンドポイント追加（ブラウザでXML表示）

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,8 @@
+/rss
+  Content-Type: application/rss+xml; charset=utf-8
+
+/rss.xml
+  Content-Type: application/rss+xml; charset=utf-8
+
+/rss-all.xml
+  Content-Type: application/rss+xml; charset=utf-8

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,6 +2,7 @@
 import { getDatabase } from '../lib/notion/client.ts'
 import { getNavLink, filePath } from '../lib/blog-helpers.ts'
 import SearchButton from './SearchButton.astro'
+import RssButton from './RssButton.astro'
 
 const database = await getDatabase()
 
@@ -53,6 +54,7 @@ const currentPath = Astro.url.pathname
     </nav>
 
     <div class="header-actions">
+      <RssButton />
       <SearchButton />
     </div>
   </div>

--- a/src/components/RssButton.astro
+++ b/src/components/RssButton.astro
@@ -1,0 +1,32 @@
+---
+import { Icon } from 'astro-icon/components'
+import { getNavLink } from '../lib/blog-helpers.ts'
+---
+
+<a href={getNavLink('/rss')} class="rss-button" title="RSS" target="_blank" rel="noopener noreferrer">
+  <Icon name="octicon:rss-24" />
+</a>
+
+<style>
+  .rss-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: transparent;
+    border: none;
+    border-radius: var(--radius);
+    padding: 0.4rem;
+    color: #777;
+    text-decoration: none;
+    transition: all 0.2s ease;
+  }
+  .rss-button:hover {
+    cursor: pointer;
+    background-color: #ddd;
+    color: #e07a3d;
+  }
+  .rss-button svg {
+    width: 20px;
+    height: 20px;
+  }
+</style>

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -8,6 +8,12 @@ type BuildRssOptions = {
   titleSuffix?: string
 }
 
+// サイト内記事のみのRSSオプション（外部リンク記事を除外）
+export const siteOnlyRssOptions: BuildRssOptions = {
+  filter: (post) => !post.ExternalLink,
+  titleSuffix: ' (サイト内のみ)',
+}
+
 export async function buildRssResponse(options: BuildRssOptions = {}) {
   const [posts, database] = await Promise.all([getAllPosts(), getDatabase()])
 

--- a/src/pages/feed.ts
+++ b/src/pages/feed.ts
@@ -2,7 +2,7 @@ export async function GET() {
   return new Response(null, {
     status: 301,
     headers: {
-      Location: '/rss.xml',
+      Location: '/rss',
     },
   })
 }

--- a/src/pages/rss.ts
+++ b/src/pages/rss.ts
@@ -1,0 +1,16 @@
+import { buildRssResponse } from '../lib/rss'
+
+export async function GET() {
+  const response = await buildRssResponse({
+    filter: (post) => !post.ExternalLink,
+    titleSuffix: ' (サイト内のみ)',
+  })
+
+  // ブラウザでXMLとして表示されるようにContent-Typeを設定
+  return new Response(response.body, {
+    status: response.status,
+    headers: {
+      'Content-Type': 'text/xml; charset=utf-8',
+    },
+  })
+}

--- a/src/pages/rss.ts
+++ b/src/pages/rss.ts
@@ -1,16 +1,14 @@
-import { buildRssResponse } from '../lib/rss'
+import { buildRssResponse, siteOnlyRssOptions } from '../lib/rss'
 
 export async function GET() {
-  const response = await buildRssResponse({
-    filter: (post) => !post.ExternalLink,
-    titleSuffix: ' (サイト内のみ)',
-  })
+  const response = await buildRssResponse(siteOnlyRssOptions)
 
-  // ブラウザでXMLとして表示されるようにContent-Typeを設定
+  // 元のヘッダーを保持しつつContent-Typeのみを上書き
+  const headers = new Headers(response.headers)
+  headers.set('Content-Type', 'text/xml; charset=utf-8')
+
   return new Response(response.body, {
     status: response.status,
-    headers: {
-      'Content-Type': 'text/xml; charset=utf-8',
-    },
+    headers,
   })
 }

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,8 +1,5 @@
-import { buildRssResponse } from '../lib/rss'
+import { buildRssResponse, siteOnlyRssOptions } from '../lib/rss'
 
 export async function GET() {
-  return buildRssResponse({
-    filter: (post) => !post.ExternalLink,
-    titleSuffix: ' (サイト内のみ)',
-  })
+  return buildRssResponse(siteOnlyRssOptions)
 }


### PR DESCRIPTION
## 概要
- `/rss` でRSSフィードをブラウザで直接表示可能に（Content-Type: text/xml）
- `/feed` のリダイレクト先を `/rss.xml` から `/rss` に変更

## 変更内容
| パス | 動作 |
|------|------|
| `/rss` | **新規** - XMLがブラウザで表示される |
| `/feed` | `/rss` へリダイレクト |
| `/rss.xml` | 既存のまま維持 |

## テスト項目
- [ ] `/rss` にアクセスしてXMLが表示されることを確認
- [ ] `/feed` にアクセスして `/rss` にリダイレクトされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)