### PR TITLE
feat: モバイル版記事リストUIの改善

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -248,7 +248,7 @@ const rightPosts = allPosts
 
         {/* 右側: 全プラットフォーム混合リスト（サムネイル付き） */}
         <div class="list-column">
-          <div class="list-header">
+          <div class="list-header" role="heading" aria-level="3">
             <span class="list-header-title">More</span>
           </div>
           <ul class="posts-list">
@@ -712,7 +712,7 @@ const rightPosts = allPosts
     content: '';
     width: 3px;
     height: 1em;
-    background: linear-gradient(180deg, var(--accents-1) 0%, #d4693a 100%);
+    background: linear-gradient(180deg, var(--accents-1) 0%, var(--accents-1-dark, #d4693a) 100%);
     border-radius: 1px;
   }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -248,6 +248,9 @@ const rightPosts = allPosts
 
         {/* 右側: 全プラットフォーム混合リスト（サムネイル付き） */}
         <div class="list-column">
+          <div class="list-header">
+            <span class="list-header-title">More</span>
+          </div>
           <ul class="posts-list">
             {
               rightPosts.map((post) => {
@@ -268,14 +271,16 @@ const rightPosts = allPosts
                       </span>
                       <span class="post-item-title">{post.Title}</span>
                       <span class="post-item-meta">
-                        {isNew(post.Date) && (
-                          <span class="new-badge-small">NEW</span>
-                        )}
-                        <span
-                          class="post-item-platform"
-                          style={`--platform-color: ${config.color}`}
-                        >
-                          {config.label}
+                        <span class="post-item-badges">
+                          {isNew(post.Date) && (
+                            <span class="new-badge-small">NEW</span>
+                          )}
+                          <span
+                            class="post-item-platform"
+                            style={`--platform-color: ${config.color}`}
+                          >
+                            {config.label}
+                          </span>
                         </span>
                         <span class="post-item-date">
                           {getDateStr(post.Date)}
@@ -686,6 +691,39 @@ const rightPosts = allPosts
     white-space: nowrap;
   }
 
+  /* バッジ横並びラッパー */
+  .post-item-badges {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  /* 一覧ヘッダー */
+  .list-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    background: var(--hover-bg);
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  .list-header::before {
+    content: '';
+    width: 3px;
+    height: 1em;
+    background: linear-gradient(180deg, var(--accents-1) 0%, #d4693a 100%);
+    border-radius: 1px;
+  }
+
+  .list-header-title {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--accents-2);
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+  }
+
   /* もっと見るボタン */
   .see-more-wrapper {
     margin-top: 2rem;
@@ -887,6 +925,15 @@ const rightPosts = allPosts
     .post-item-thumb {
       width: 88px;
       height: 50px;
+    }
+
+    /* 一覧ヘッダーのモバイル調整 */
+    .list-header {
+      padding: 0.4rem 0.6rem;
+    }
+
+    .list-header-title {
+      font-size: 0.7rem;
     }
   }
 </style>


### PR DESCRIPTION
## Summary
- NEWバッジとPlatformバッジを横並びに変更し、NEWバッジ表示時の行高さの不整合を修正
- 一覧セクションに「MORE」ヘッダーを追加し、Blog/note/Zennのピックアップセクションとの区別を明確化
- モバイル用のレスポンシブスタイル調整を追加

## Test plan
- [ ] モバイルビュー（375px幅）でNEWバッジありの記事となしの記事が同じ高さであることを確認
- [ ] 「MORE」ヘッダーがオレンジのアクセントライン付きで表示されることを確認
- [ ] PC版でレイアウトが崩れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)